### PR TITLE
fix: description style with newline

### DIFF
--- a/src/views/album.vue
+++ b/src/views/album.vue
@@ -108,8 +108,11 @@
       :showFooter="false"
       :clickOutsideHide="true"
       title="专辑介绍"
-      >{{ album.description }}</Modal
     >
+      <p class="description-fulltext">
+        {{ album.description }}
+      </p>
+    </Modal>
     <ContextMenu ref="albumMenu">
       <div class="item">{{ $t("contextMenu.playNext") }}</div>
       <div class="item" @click="likeAlbum(true)">{{
@@ -311,6 +314,7 @@ export default {
       -webkit-line-clamp: 3;
       overflow: hidden;
       cursor: pointer;
+      white-space: pre-line;
       &:hover {
         transition: opacity 0.3s;
         opacity: 0.88;
@@ -360,5 +364,13 @@ export default {
     color: var(--color-text);
     margin-bottom: 20px;
   }
+}
+.description-fulltext {
+  font-size: 16px;
+  margin-top: 24px;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  white-space: pre-line;
 }
 </style>


### PR DESCRIPTION
description can contain `\n` add `white-space: pre-line` to make it display better.

-----

![old](https://user-images.githubusercontent.com/16515468/107127699-db90b400-68f2-11eb-953c-fb72e29ca1b9.png)

![new](https://user-images.githubusercontent.com/16515468/107127718-fb27dc80-68f2-11eb-944f-4f01855ce4b6.png)