### PR TITLE
fix: change source and add track name in discord large image text

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "crypto-js": "^4.0.0",
     "dayjs": "^1.8.36",
     "discord-rich-presence": "^0.0.8",
-    "discord-rpc": "^3.2.0",
     "electron": "^12.0.0",
     "electron-builder": "^22.10.5",
     "electron-context-menu": "^2.3.0",

--- a/src/electron/ipcMain.js
+++ b/src/electron/ipcMain.js
@@ -69,7 +69,7 @@ export function initIpcMain(win, store) {
       state: track.al.name,
       endTimestamp: Date.now() + track.dt,
       largeImageKey: "logo",
-      largeImageText: "YesPlayMusic",
+      largeImageText: "Listening " + track.name,
       smallImageKey: "play",
       smallImageText: "Playing",
       instance: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4300,12 +4300,12 @@ dir-glob@^3.0.1:
 
 discord-rich-presence@^0.0.8:
   version "0.0.8"
-  resolved "https://registry.npm.taobao.org/discord-rich-presence/download/discord-rich-presence-0.0.8.tgz#7a2b41ff87a278e8a2c8835cd91c9890d6b9fbdd"
-  integrity sha1-eitB/4eieOiiyINc2RyYkNa5+90=
+  resolved "https://registry.yarnpkg.com/discord-rich-presence/-/discord-rich-presence-0.0.8.tgz#7a2b41ff87a278e8a2c8835cd91c9890d6b9fbdd"
+  integrity sha512-IpVMPjv15C9UvppxvrrGdv6bzQHOW1P1vLoMH15HvdJwGJ3dBd2bnrJ63Uy36YRUfrAMxGLiwUDHncvC8AuPaQ==
   dependencies:
     discord-rpc "github:discordjs/rpc"
 
-discord-rpc@^3.2.0, "discord-rpc@github:discordjs/rpc":
+"discord-rpc@github:discordjs/rpc":
   version "3.2.0"
   resolved "https://codeload.github.com/discordjs/rpc/tar.gz/32f1b9f8c47cf82ab87a83391ca9a9115513f01e"
   dependencies:


### PR DESCRIPTION
![](https://user-images.githubusercontent.com/16725418/111478526-1e07a500-876b-11eb-9fb2-d8729797a858.png)

在Large Image显示歌曲名是看到隔壁Spotify的，感觉该给整一个

主要的还是更改了淘宝源到yarn源