### PR TITLE
feat: add search in playlist | 增加歌单内搜索

### DIFF
--- a/src/views/playlist.vue
+++ b/src/views/playlist.vue
@@ -86,6 +86,7 @@
             <input
               :placeholder="inputFocus ? '' : $t('playlist.search')"
               v-model.trim="inputSearchKeyWords"
+              v-focus="displaySearchInPlaylist"
               @input="inputDebounce()"
               @focus="inputFocus = true"
               @blur="inputFocus = false"
@@ -492,6 +493,13 @@ export default {
       this.debounceTimeout = setTimeout(() => {
         this.searchKeyWords = this.inputSearchKeyWords;
       }, 600);
+    },
+  },
+  directives: {
+    focus: {
+      inserted: function (el) {
+        el.focus();
+      },
     },
   },
 };

--- a/src/views/playlist.vue
+++ b/src/views/playlist.vue
@@ -420,11 +420,11 @@ export default {
           }
         });
     },
-    loadMore() {
+    loadMore(loadNum = 50) {
       let trackIDs = this.playlist.trackIds.filter((t, index) => {
         if (
           index > this.lastLoadedTrackIndex &&
-          index <= this.lastLoadedTrackIndex + 500
+          index <= this.lastLoadedTrackIndex + loadNum
         )
           return t;
       });
@@ -479,6 +479,8 @@ export default {
       if (this.displaySearchInPlaylist == false) {
         this.searchKeyWords = "";
         this.inputSearchKeyWords = "";
+      } else {
+        this.loadMore(500);
       }
     },
     removeTrack(trackID) {

--- a/src/views/playlist.vue
+++ b/src/views/playlist.vue
@@ -79,8 +79,21 @@
           </ButtonTwoTone>
         </div>
       </div>
+      <div class="search-box" v-if="displaySearchInPlaylist">
+        <div class="container" :class="{ active: inputFocus }">
+          <svg-icon icon-class="search" />
+          <div class="input">
+            <input
+              :placeholder="inputFocus ? '' : $t('playlist.search')"
+              v-model.trim="inputSearchKeyWords"
+              @input="inputDebounce()"
+              @focus="inputFocus = true"
+              @blur="inputFocus = false"
+            />
+          </div>
+        </div>
+      </div>
     </div>
-
     <div class="special-playlist" v-if="specialPlaylistInfo !== undefined">
       <div
         class="title"
@@ -136,7 +149,7 @@
     </div>
 
     <TrackList
-      :tracks="tracks"
+      :tracks="filteredTracks"
       :type="'playlist'"
       :id="playlist.id"
       :extraContextMenuItem="
@@ -158,6 +171,7 @@
       <div class="item" @click="likePlaylist(true)">{{
         playlist.subscribed ? "从音乐库删除" : "保存到音乐库"
       }}</div>
+      <div class="item" @click="searchInPlaylist()">歌单内搜索</div>
       <div
         class="item"
         v-if="playlist.creator.userId === data.user.userId"
@@ -302,6 +316,11 @@ export default {
       tracks: [],
       loadingMore: false,
       lastLoadedTrackIndex: 9,
+      displaySearchInPlaylist: false,
+      searchKeyWords: "", // 搜索使用的关键字
+      inputSearchKeyWords: "", // 搜索框中正在输入的关键字
+      inputFocus: false,
+      debounceTimeout: null,
     };
   },
   created() {
@@ -326,6 +345,22 @@ export default {
       return (
         this.playlist.creator.userId === this.data.user.userId &&
         this.playlist.id !== this.data.likedSongPlaylistID
+      );
+    },
+    filteredTracks() {
+      return this.tracks.filter(
+        (track) =>
+          track.name
+            .toLowerCase()
+            .includes(this.searchKeyWords.toLowerCase()) ||
+          track.al.name
+            .toLowerCase()
+            .includes(this.searchKeyWords.toLowerCase()) ||
+          track.ar.find((artist) =>
+            artist.name
+              .toLowerCase()
+              .includes(this.searchKeyWords.toLowerCase())
+          )
       );
     },
   },
@@ -388,7 +423,7 @@ export default {
       let trackIDs = this.playlist.trackIds.filter((t, index) => {
         if (
           index > this.lastLoadedTrackIndex &&
-          index <= this.lastLoadedTrackIndex + 50
+          index <= this.lastLoadedTrackIndex + 500
         )
           return t;
       });
@@ -438,12 +473,25 @@ export default {
     editPlaylist() {
       alert("此功能开发中");
     },
+    searchInPlaylist() {
+      this.displaySearchInPlaylist = !this.displaySearchInPlaylist;
+      if (this.displaySearchInPlaylist == false) {
+        this.searchKeyWords = "";
+        this.inputSearchKeyWords = "";
+      }
+    },
     removeTrack(trackID) {
       if (!isAccountLoggedIn()) {
         this.showToast("此操作需要登录网易云账号");
         return;
       }
       this.tracks = this.tracks.filter((t) => t.id !== trackID);
+    },
+    inputDebounce() {
+      if (this.debounceTimeout) clearTimeout(this.debounceTimeout);
+      this.debounceTimeout = setTimeout(() => {
+        this.searchKeyWords = this.inputSearchKeyWords;
+      }, 600);
     },
   },
 };
@@ -453,6 +501,7 @@ export default {
 .playlist-info {
   display: flex;
   margin-bottom: 72px;
+  position: relative;
   .info {
     display: flex;
     flex-direction: column;
@@ -708,6 +757,65 @@ export default {
       vertical-align: -7px;
       border-radius: 50%;
       border: rgba(0, 0, 0, 0.2);
+    }
+  }
+}
+
+.search-box {
+  display: flex;
+  position: absolute;
+  right: 20px;
+  bottom: -55px;
+  justify-content: flex-end;
+  -webkit-app-region: no-drag;
+
+  .container {
+    display: flex;
+    align-items: center;
+    height: 32px;
+    background: var(--color-secondary-bg-for-transparent);
+    border-radius: 8px;
+    width: 200px;
+  }
+
+  .svg-icon {
+    height: 15px;
+    width: 15px;
+    color: var(--color-text);
+    opacity: 0.28;
+    margin: {
+      left: 8px;
+      right: 4px;
+    }
+  }
+
+  input {
+    font-size: 16px;
+    border: none;
+    background: transparent;
+    width: 96%;
+    font-weight: 600;
+    margin-top: -1px;
+    color: var(--color-text);
+  }
+
+  .active {
+    background: var(--color-primary-bg-for-transparent);
+    input,
+    .svg-icon {
+      opacity: 1;
+      color: var(--color-primary);
+    }
+  }
+}
+
+[data-theme="dark"] {
+  .search-box {
+    .active {
+      input,
+      .svg-icon {
+        color: var(--color-text);
+      }
     }
   }
 }


### PR DESCRIPTION
1. 增加歌单内搜索
2. 搜索框位置基于`playlist-info`相对定位
3. 在搜索框输入会有0.6秒的防抖
4. 根据此Issue的说法 我修改了`loadMore()` 从每次50首到500首
https://github.com/Binaryify/NeteaseCloudMusicApi/issues/452#issuecomment-474221568

目前的问题是，如果用户歌单过大，那么歌单内搜索会无法搜索到还未请求detail的歌，除非用户拉到了歌单底部手动`loadMore()`

诚然可以在用户搜索时获取所有歌的detail，但我暂不清楚网易云官方是怎么做的，所以没有点子。

需要一些主意

目前效果：

https://user-images.githubusercontent.com/16725418/111831577-8cdf2c80-892a-11eb-857d-eb54a173b103.mp4



