### PR TITLE
fix: likelist does not change when account switching | 修复切换账号后喜欢列表不变

### DIFF
--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -10,6 +10,8 @@ export function doLogout() {
   store.commit("updateData", { key: "user", value: {} });
   // 更新状态仓库中的登录状态
   store.commit("updateData", { key: "loginMode", value: null });
+  // 更新状态仓库中的喜欢列表
+  store.commit("updateData", { key: "likedSongPlaylistID", value: undefined });
 }
 
 // MUSIC_U 只有在账户登录的情况下才有


### PR DESCRIPTION
相关Issue： #538 

登出时更新一下`LocalStorage-data`中的`likedSongPlaylistID`