### PR TITLE
perf(lyrics): optimize GPU usage for dynamic lyric backgrounds

### DIFF
--- a/src/views/lyrics.vue
+++ b/src/views/lyrics.vue
@@ -5,16 +5,16 @@
         v-if="this.$store.state.settings.showLyricsDynamicBackground"
         class="dynamic-background"
       >
-        <div v-show="this.$store.state.showLyrics">
-          <div
-            class="top-right"
-            :style="{ backgroundImage: `url(${imageUrl})` }"
-          />
-          <div
-            class="bottom-left"
-            :style="{ backgroundImage: `url(${imageUrl})` }"
-          />
-        </div>
+        <div
+          v-show="this.$store.state.showLyrics"
+          class="top-right"
+          :style="{ backgroundImage: `url(${imageUrl})` }"
+        />
+        <div
+          v-show="this.$store.state.showLyrics"
+          class="bottom-left"
+          :style="{ backgroundImage: `url(${imageUrl})` }"
+        />
       </div>
       <div class="left-side">
         <div>
@@ -216,6 +216,9 @@ export default {
     imageUrl() {
       return this.player.currentTrack?.al?.picUrl + "?param=1024y1024";
     },
+    bgImageUrl() {
+      return this.player.currentTrack?.al?.picUrl + "?param=500y500";
+    },
     progress: {
       get() {
         return this.playerRef.progress;
@@ -393,14 +396,14 @@ export default {
 }
 
 .dynamic-background {
+  filter: blur(50px) opacity(0.6) contrast(var(--contrast-dynamic-background))
+    brightness(var(--brightness-dynamic-background));
   .top-right,
   .bottom-left {
     z-index: 0;
-    width: 140vw;
-    height: 140vw;
+    width: 14vw;
+    height: 14vw;
     position: absolute;
-    filter: blur(50px) opacity(0.6) contrast(var(--contrast-dynamic-background))
-      brightness(var(--brightness-dynamic-background));
     background-size: cover;
     animation: rotate 150s linear infinite;
   }
@@ -421,10 +424,10 @@ export default {
 
 @keyframes rotate {
   0% {
-    transform: rotate(0deg);
+    transform: rotate(0deg) scale(10);
   }
   100% {
-    transform: rotate(360deg);
+    transform: rotate(360deg) scale(10);
   }
 }
 


### PR DESCRIPTION
调整了下css，优化了歌词动态背景的GPU占用。
一台7700HQ的HD630，测试功耗会降低4w左右，频率降低0.4Ghz，占用率降低10-25%之间。
一台MBP13的Iris Plus 645，频率降低0.2-0.3Ghz，占用率降低20-30%左右。

应该可以还好，暂时先提交。

#484