### PR TITLE
fix: output device switch | 修复设备切换

### DIFF
--- a/src/views/settings.vue
+++ b/src/views/settings.vue
@@ -82,7 +82,7 @@
           <div class="title"> {{ $t('settings.deviceSelector') }} </div>
         </div>
         <div class="right">
-          <select v-model="outputDevice" :disabled="withoutAudioPrivilege">
+          <select v-model="outputDevice">
             <option
               v-for="device in allOutputDevices"
               :key="device.deviceId"
@@ -423,7 +423,6 @@ export default {
           label: 'settings.permissionRequired',
         },
       ],
-      withoutAudioPrivilege: true,
     };
   },
   computed: {


### PR DESCRIPTION
修复切换框Disabled

因为Electron外不显示，那就不需要考虑权限问题😂