### PR TITLE
fix: make Express listen on localhost only

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -100,7 +100,7 @@ class Background {
           });
         });
     });
-    this.expressApp = expressApp.listen(27232);
+    this.expressApp = expressApp.listen(27232, '127.0.0.1');
   }
 
   createWindow() {


### PR DESCRIPTION
应用的 Express 的端口默认对所有接口开放，这会导致：

* macOS 上，系统会弹出防火墙提示

<img width="1056" alt="截屏2021-05-08 下午6 42 14" src="https://user-images.githubusercontent.com/8158163/117536424-7fdae180-b02d-11eb-912f-8468e26eb631.png">

* 潜在的安全问题

该 PR 修改 [`express.listen`](https://expressjs.com/en/api.html#app.listen) 参数，使其仅对本机开放端口