### PR TITLE
fix: cloudpan music playing error | 云盘音乐播放错误

### DIFF
--- a/src/utils/db.js
+++ b/src/utils/db.js
@@ -52,7 +52,10 @@ async function deleteExcessCache() {
 
 export function cacheTrackSource(trackInfo, url, bitRate, from = 'netease') {
   const name = trackInfo.name;
-  const artist = trackInfo.ar[0]?.name || trackInfo.artists[0]?.name;
+  const artist =
+    (trackInfo.ar && trackInfo.ar[0]?.name) ||
+    (trackInfo.artists && trackInfo.artists[0]?.name) ||
+    'Unknown';
   let cover = trackInfo.al.picUrl;
   if (cover.slice(0, 5) !== 'https') {
     cover = 'https' + cover.slice(4);


### PR DESCRIPTION
歌手名的问题，自己上传的歌曲很多是没有歌手名字的，用`Unknown`替代。
报错原因是索引了`TrackInfo.artists`的0号元素，但`TrackInfo`里没有`artists`。

相关Issue: #720 #759 #773 #763 (其实是我自己听着听着发现听不了 修完搜了搜发现还挺多Issue的😂)