### PR TITLE
fix: empty Album artist page can't open | 修复当歌手没有专辑时无法打开歌手页的BUG

### DIFF
--- a/src/views/artist.vue
+++ b/src/views/artist.vue
@@ -42,7 +42,7 @@
         </div>
       </div>
     </div>
-    <div class="latest-release">
+    <div v-if="latestRelease !== undefined" class="latest-release">
       <div class="section-title">{{ $t('artist.latestRelease') }}</div>
       <div class="release">
         <div class="container">


### PR DESCRIPTION
fix #836 