### PR TITLE
fix: 修改歌名翻译的实现，以避免展示重复的信息

### DIFF
--- a/src/components/TrackListItem.vue
+++ b/src/components/TrackListItem.vue
@@ -43,8 +43,8 @@
           <span v-if="isAlbum && track.mark === 1318912" class="explicit-symbol"
             ><ExplicitSymbol
           /></span>
-          <span v-if="isTranslate" :title="translate" class="translate">
-            ({{ translate }})
+          <span v-if="isSubTitle" :title="subTitle" class="subTitle">
+            ({{ subTitle }})
           </span>
         </div>
         <div v-if="!isAlbum" class="artist">
@@ -124,11 +124,18 @@ export default {
     album() {
       return this.track.album || this.track.al || this.track?.simpleSong?.al;
     },
-    translate() {
-      let t;
-      if (this.track?.tns?.length > 0) t = this.track.tns[0];
-      else t = this.track.alia[0];
-      return t;
+    subTitle() {
+      let tns = undefined;
+      if (this.track.tns?.length > 0 && this.track.name !== this.track.tns[0]) {
+        tns = this.track.tns[0];
+      }
+
+      //优先显示alia
+      if (this.$store.state.settings.subTitleDefault) {
+        return this.track.alia?.length > 0 ? this.track.alia[0] : tns;
+      } else {
+        return tns === undefined ? this.track.alia[0] : tns;
+      }
     },
     type() {
       return this.$parent.type;
@@ -136,8 +143,11 @@ export default {
     isAlbum() {
       return this.type === 'album';
     },
-    isTranslate() {
-      return this.track?.tns?.length > 0 || this.track.alia?.length > 0;
+    isSubTitle() {
+      return (
+        (this.track.tns?.length > 0 && this.track.name !== this.track.tns[0]) ||
+        this.track.alia?.length > 0
+      );
     },
     isPlaylist() {
       return this.type === 'playlist';
@@ -294,7 +304,7 @@ button {
         font-size: 14px;
         opacity: 0.72;
       }
-      .translate {
+      .subTitle {
         color: #aeaeae;
         margin-left: 4px;
       }
@@ -398,7 +408,7 @@ button {
   .title,
   .album,
   .time,
-  .title-and-artist .translate {
+  .title-and-artist .subTitle {
     color: var(--color-primary);
   }
   .title .featured,

--- a/src/locale/lang/en.js
+++ b/src/locale/lang/en.js
@@ -155,6 +155,7 @@ export default {
     enableDiscordRichPresence: 'Enable Discord Rich Presence',
     enableGlobalShortcut: 'Enable Global Shortcut',
     showLibraryDefault: 'Show library default',
+    subTitleDefault: 'Sub title alia default',
     lyricsBackground: {
       text: 'Show Lyrics Background',
       off: 'Off',

--- a/src/locale/lang/tr.js
+++ b/src/locale/lang/tr.js
@@ -150,6 +150,7 @@ export default {
     showPlaylistsByAppleMusic: "Apple Music'in Çalma Listelerini Göster",
     enableDiscordRichPresence: 'Discord gösterimini aktifleştir',
     showLibraryDefault: 'Kitaplık Varsayılanını göster',
+    subTitleDefault: 'Sub title alia default',
     lyricsBackground: {
       text: 'Şarkı Sözleri Arka Planını Göster',
       off: 'kapalı',

--- a/src/locale/lang/zh-CN.js
+++ b/src/locale/lang/zh-CN.js
@@ -156,6 +156,7 @@ export default {
     enableDiscordRichPresence: '启用 Discord Rich Presence',
     enableGlobalShortcut: '启用全局快捷键',
     showLibraryDefault: '启动后显示音乐库',
+    subTitleDefault: '副标题使用别名',
     lyricsBackground: {
       text: '显示歌词背景',
       off: '关闭',

--- a/src/locale/lang/zh-TW.js
+++ b/src/locale/lang/zh-TW.js
@@ -153,6 +153,7 @@ export default {
     enableDiscordRichPresence: '啟用 Discord Rich Presence',
     enableGlobalShortcut: '啟用全域快捷鍵',
     showLibraryDefault: '啟動後顯示音樂庫',
+    subTitleDefault: '副標題使用別名',
     lyricsBackground: {
       text: '顯示歌詞背景',
       off: '關閉',

--- a/src/store/initLocalStorage.js
+++ b/src/store/initLocalStorage.js
@@ -26,6 +26,7 @@ let localStorage = {
     enableDiscordRichPresence: false,
     enableGlobalShortcut: true,
     showLibraryDefault: false,
+    subTitleDefault: false,
     enabledPlaylistCategories,
     proxyConfig: {
       protocol: 'noProxy',

--- a/src/views/settings.vue
+++ b/src/views/settings.vue
@@ -337,6 +337,24 @@
           </div>
         </div>
       </div>
+
+      <div class="item">
+        <div class="left">
+          <div class="title">{{ $t('settings.subTitleDefault') }}</div>
+        </div>
+        <div class="right">
+          <div class="toggle">
+            <input
+              id="sub-title-default"
+              v-model="subTitleDefault"
+              type="checkbox"
+              name="sub-title-default"
+            />
+            <label for="sub-title-default"></label>
+          </div>
+        </div>
+      </div>
+
       <div class="item">
         <div class="left">
           <div class="title" style="transform: scaleX(-1)">🐈️ 🏳️‍🌈</div>
@@ -743,6 +761,17 @@ export default {
       set(value) {
         this.$store.commit('updateSettings', {
           key: 'enableDiscordRichPresence',
+          value,
+        });
+      },
+    },
+    subTitleDefault: {
+      get() {
+        return this.settings.subTitleDefault;
+      },
+      set(value) {
+        this.$store.commit('updateSettings', {
+          key: 'subTitleDefault',
           value,
         });
       },


### PR DESCRIPTION
close #957 

change: translate修改为subTitle(命名)

add: 添加一个设置项以指示subTitle是否优先显示别名而不是翻译

fix:当没有可用的别名且翻译与歌名相同时，不显示subTitle