### PR TITLE
to fix: #1063 #1010

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -347,10 +347,12 @@ class Background {
       }
 
       // create dock menu for macOS
-      app.dock.setMenu(createDockMenu(this.window));
+      const createdDockMenu = createDockMenu(this.window);
+      if (createDockMenu && app.dock) app.dock.setMenu(createdDockMenu);
 
       // create touch bar
-      this.window.setTouchBar(createTouchBar(this.window));
+      const createdTouchBar = createTouchBar(this.window);
+      if (createdTouchBar) this.window.setTouchBar(createdTouchBar);
 
       // register global shortcuts
       if (this.store.get('settings.enableGlobalShortcut') !== false) {


### PR DESCRIPTION
运行环境：Windows 11 21H2
出现的问题：启动之后无法自动打开全局快捷键，需要到设置中手动关闭再打开。
测试：
```shell
yarn electron:serve
```
报错：
```
TypeError: Cannot read property 'setMenu' of undefined
    at App.eval (webpack:///./src/background.js?:357:59)
    at App.emit (events.js:315:20)
```
在 Windows 电脑上可能无设置dock的方法，故加上是否为空的判断。
结果：在本机的Electron上能够在启动时打开全局快捷键。