### PR TITLE
fix: `toast` covered by `modal` | 修复`toast`被`modal`遮挡

### DIFF
--- a/src/components/Toast.vue
+++ b/src/components/Toast.vue
@@ -30,7 +30,7 @@ export default {
   border-radius: 8px;
   box-sizing: border-box;
   padding: 6px 12px;
-  z-index: 100;
+  z-index: 1010;
 }
 
 [data-theme='dark'] {


### PR DESCRIPTION
After:
<img width="332" alt="image" src="https://user-images.githubusercontent.com/16725418/147492026-2e4fb067-9eb9-4f99-bf32-2367ffe6fff4.png">
Before:
添加重复歌曲到歌单时发现`Toast`被挡在后面了，狂摁了3秒添加寻思咋回事呢😂