### PR TITLE
fix: library extract lyric part

### DIFF
--- a/src/views/library.vue
+++ b/src/views/library.vue
@@ -211,7 +211,7 @@ import MvRow from '@/components/MvRow.vue';
  * @returns {string} The lyric part
  */
 function extractLyricPart(rawLyric) {
-  return rawLyric.split(']')[1].trim();
+  return rawLyric.split(']').pop().trim();
 }
 
 export default {


### PR DESCRIPTION
修复因为一句歌词同时存在多个时间戳，导致library取词取到时间戳的bug

lyric:
![image](https://user-images.githubusercontent.com/34763046/148609810-b3e5d1a4-447b-4bf8-ac61-e6932b80411e.png)

before:
![image](https://user-images.githubusercontent.com/34763046/148609589-8d25c5d7-5c39-43eb-a06a-fc7049f1f51c.png)

after:
![image](https://user-images.githubusercontent.com/34763046/148609626-02cc2f87-28c8-437e-98a5-85e1342b40fe.png)
