### PR TITLE
fix: wrong trim all white space lyric

### DIFF
--- a/src/utils/lyrics.js
+++ b/src/utils/lyrics.js
@@ -28,11 +28,16 @@ export function parseLyric(lrc) {
         lrcObj.push({
           time: time,
           rawTime: timeRegExpArr[0],
-          content: content.trim(),
+          content: trimContent(content),
         });
       }
     }
   }
   lrcObj.sort((a, b) => a.time - b.time);
   return lrcObj;
+}
+
+function trimContent(content) {
+  let t = content.trim();
+  return t.length < 1 ? content : t;
 }


### PR DESCRIPTION
修复在之前的更改中，错误的对全为空格的内容进行trim()操作，导致歌词页面的歌词进度错位的问题