### PR TITLE
fix(components/navbar): Windows 聚焦在关闭按钮时“x“按钮应为白色

### DIFF
--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -269,7 +269,8 @@ nav {
         }
         &.close {
           &:hover {
-            background: rgba(232, 17, 35, 0.9);
+            background: #c42c1b;
+            color: rgba(255, 255, 255, 0.8);
           }
           &:active {
             background: #f1707a;


### PR DESCRIPTION
Fix #1333