### PR TITLE
fix: firefox scrollbar

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -124,6 +124,7 @@ main {
   overflow: auto;
   padding: 64px 10vw 96px 10vw;
   box-sizing: border-box;
+  scrollbar-width: none; // firefox
 }
 
 @media (max-width: 1336px) {


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/34763046/159119783-159fd520-c168-41d8-9947-528253d022ee.png)

after:
![image](https://user-images.githubusercontent.com/34763046/159119789-c8fd9ca2-8ccf-4635-9bef-1af3314d90d0.png)
