### PR TITLE
fix(components/ArtistsInline): 限制可用布局空间 & 使用歌手名字做 key

### DIFF
--- a/packages/renderer/src/components/ArtistsInline.tsx
+++ b/packages/renderer/src/components/ArtistsInline.tsx
@@ -8,9 +8,9 @@ const ArtistInline = ({
   if (!artists) return <div></div>
 
   return (
-    <div className={classNames('flex truncate', className)}>
+    <div className={classNames('line-clamp-1', className)}>
       {artists.map((artist, index) => (
-        <span key={artist.id}>
+        <span key={artist.name}>
           <span className={classNames({ 'hover:underline': !!artist.id })}>
             {artist.name}
           </span>


### PR DESCRIPTION
fix: 歌手列表长度溢出
fix: 使用歌手名字做key，让Player component里id为0的歌手也被刷新