### PR TITLE
feat: 支持二维码登录

### DIFF
--- a/packages/renderer/src/pages/Login.tsx
+++ b/packages/renderer/src/pages/Login.tsx
@@ -202,12 +202,11 @@ const LoginWithEmail = () => {
   const navigate = useNavigate()
 
   const doLogin = useMutation(
-    () => {
-      return loginWithEmail({
+    () =>
+      loginWithEmail({
         email: email.trim(),
         md5_password: md5(password.trim()),
-      })
-    },
+      }),
     {
       onSuccess: result => {
         if (result?.code !== 200) {

--- a/packages/renderer/src/pages/Login.tsx
+++ b/packages/renderer/src/pages/Login.tsx
@@ -314,9 +314,8 @@ const LoginWithPhone = () => {
 
 // Login with QRCode
 const LoginWithQRCode = () => {
-  const [qrCodeKey, setQrCodeKey] = useState('')
+  const [qrCodeKey, setQrCodeKey] = useState('Not Ready')
   const [qrCodeMessage, setQrCodeMessage] = useState('扫码登录')
-  const [qrCodeUrl, setQrCodeUrl] = useState('Not Ready')
   const [qrCodeImage, setQrCodeImage] = useState('')
 
   const navigate = useNavigate()
@@ -365,12 +364,12 @@ const LoginWithQRCode = () => {
     }
   }, 1000)
 
-  useMemo(async () => {
-    setQrCodeUrl(`https://music.163.com/login?codekey=${qrCodeKey}`)
+  const qrCodeUrl = useMemo(() => {
+    return `https://music.163.com/login?codekey=${qrCodeKey}`
   }, [qrCodeKey])
 
-  useMemo(async () => {
-    try {
+  useEffect(() => {
+    const updateImage = async () => {
       const image = await QRCode.toDataURL(qrCodeUrl, {
         width: 1024,
         margin: 0,
@@ -380,9 +379,8 @@ const LoginWithQRCode = () => {
         },
       })
       setQrCodeImage(image)
-    } catch (err) {
-      console.error(err)
     }
+    updateImage()
   }, [qrCodeUrl])
 
   return (

--- a/packages/renderer/src/pages/Login.tsx
+++ b/packages/renderer/src/pages/Login.tsx
@@ -364,9 +364,10 @@ const LoginWithQRCode = () => {
     }
   }, 1000)
 
-  const qrCodeUrl = useMemo(() => {
-    return `https://music.163.com/login?codekey=${qrCodeKey}`
-  }, [qrCodeKey])
+  const qrCodeUrl = useMemo(
+    () => `https://music.163.com/login?codekey=${qrCodeKey}`,
+    [qrCodeKey]
+  )
 
   useEffect(() => {
     const updateImage = async () => {

--- a/packages/renderer/src/utils/cookie.ts
+++ b/packages/renderer/src/utils/cookie.ts
@@ -1,7 +1,7 @@
 import Cookies from 'js-cookie'
 
 export function setCookies(string: string) {
-  const cookies = string.replaceAll(/;.*?HTTPOnly.*?;/g, ';;').split(';;')
+  const cookies = string.replace(/;.*?HTTPOnly.*?;/g, ';;').split(';;')
   cookies.map(cookie => {
     const cookieKeyValue = cookie.split(';')[0].split('=')
     const [key, value] = cookieKeyValue

--- a/packages/renderer/src/utils/cookie.ts
+++ b/packages/renderer/src/utils/cookie.ts
@@ -1,7 +1,7 @@
 import Cookies from 'js-cookie'
 
 export function setCookies(string: string) {
-  const cookies = string.replace('HTTPOnly', '').split(';;')
+  const cookies = string.replaceAll(/;.*?HTTPOnly.*?;/g, ';;').split(';;')
   cookies.map(cookie => {
     const cookieKeyValue = cookie.split(';')[0].split('=')
     const [key, value] = cookieKeyValue


### PR DESCRIPTION
1. 修复因为replace函数导致的bug

     - 原来的replace('HTTPOnly','')函数只能替换一个，所以替换为replaceAll。
     - 在扫码返回的cookie中HTTPOnly是以'; HTTPOnly;'出现的，为了能够同时替换含有空格和不含空格的格式，使用了正则表达式。

2. 支持二维码登录