### PR TITLE
fix(components/DailyTracksCard): 修复了每日推荐在 Safari 不显示圆角的bug

### DIFF
--- a/src/components/DailyTracksCard.vue
+++ b/src/components/DailyTracksCard.vue
@@ -84,6 +84,7 @@ export default {
   cursor: pointer;
   position: relative;
   overflow: hidden;
+  z-index: 1;
 }
 
 img {


### PR DESCRIPTION
# 修复前：

![macOS Safari](https://s2.loli.net/2022/03/26/wBNYtdGnPekvXq6.png)
---
![iPadOS Safari](https://s2.loli.net/2022/03/26/ReEuYaLBn7M1cKl.png)
---
![iOS Safari](https://s2.loli.net/2022/03/26/HTg3hvoKZj2r1Qc.png)

# 修复后：

![macOS Safari](https://s2.loli.net/2022/03/26/K5HjdmxypFzBWEs.png)
---
![iPadOS Safari](https://s2.loli.net/2022/03/26/aPUdJtiSq7kMofx.png)
---
![iOS Safari](https://s2.loli.net/2022/03/26/LCcKG3p7FvYDNSu.png)