### PR TITLE
fix(ci/build): 暫時不要登入

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,8 +39,9 @@ jobs:
       - name: Install Snapcraft (on Ubuntu)
         uses: samuelmeuli/action-snapcraft@v1
         if: startsWith(matrix.os, 'ubuntu')
-        with:
-          snapcraft_token: ${{ secrets.snapcraft_token }}
+        # with:
+        #   Disable since the Snapcraft token is currently not working
+        #   snapcraft_token: ${{ secrets.snapcraft_token }}
 
       - name: Build/release Electron app
         uses: samuelmeuli/action-electron-builder@v1.6.0


### PR DESCRIPTION
目前 YPM 的 snapcraft_token 似乎失效了？但 0.4.4 release 前還是得解決 snapcraft 的問題。