### PR TITLE
refactor(utils/lyric): more powerful role matcher

### DIFF
--- a/src/renderer/utils/lyric.ts
+++ b/src/renderer/utils/lyric.ts
@@ -59,7 +59,7 @@ function parseLyric(lrc: string): ParsedLyric[] {
     if (
       content.match(
         // https://regexr.com/6j8pf
-        .*(?<role>作曲|作词|编曲|制作|Producers|Producer|Produced|贝斯|工程师|吉他|合成器|助理|编程|制作|和声|母带|人声|鼓|混音|中提琴|编写|Talkbox|钢琴|出版|录音|发行|出品|键盘|弦乐|设计|监制|原曲|演唱|声明|版权|封面|插画|统筹|企划|填词|原唱|后期|和音|琵琶).*[:：]\s*(?<name>.*)
+        /.*(?<role>作曲|作词|编曲|制作|Producers|Producer|Produced|贝斯|工程师|吉他|合成器|助理|编程|制作|和声|母带|人声|鼓|混音|中提琴|编写|Talkbox|钢琴|出版|录音|发行|出品|键盘|弦乐|设计|监制|原曲|演唱|声明|版权|封面|插画|统筹|企划|填词|原唱|后期|和音|琵琶).*[:：]\s*(?<name>.*)/
       )
     ) {
       continue

--- a/src/renderer/utils/lyric.ts
+++ b/src/renderer/utils/lyric.ts
@@ -10,7 +10,7 @@ export function lyricParser(lrc: FetchLyricResponse) {
 }
 
 /**
- * @see https://regexr.com/6e52n
+ * @see {@link https://regexr.com/6e52n}
  */
 const extractLrcRegex =
   /^(?<lyricTimestamps>(?:\[.+?\])+)(?!\[)(?<content>.+)$/gm
@@ -58,7 +58,8 @@ function parseLyric(lrc: string): ParsedLyric[] {
 
     if (
       content.match(
-        /((\s|\S)*)(作曲|作词|编曲|制作|Producers|Producer|Produced|贝斯|工程师|吉他|合成器|助理|编程|制作|和声|母带|人声|鼓|混音|中提琴|编写|Talkbox|钢琴|出版|录音|发行|出品|键盘|弦乐|设计|监制|原曲|演唱|声明|版权|封面|插画|统筹|企划|填词|原唱|后期|和音|琵琶)((\s|\S)*)(:|：)/
+        // https://regexr.com/6j8pf
+        .*(?<role>作曲|作词|编曲|制作|Producers|Producer|Produced|贝斯|工程师|吉他|合成器|助理|编程|制作|和声|母带|人声|鼓|混音|中提琴|编写|Talkbox|钢琴|出版|录音|发行|出品|键盘|弦乐|设计|监制|原曲|演唱|声明|版权|封面|插画|统筹|企划|填词|原唱|后期|和音|琵琶).*[:：]\s*(?<name>.*)
       )
     ) {
       continue


### PR DESCRIPTION
- 可以拉出角色 (role) 和名字 (name)：
  `const { role, name } = line.groups as { role: string, name?: string }`
- 移除掉某些不需要的 regex 部分（如 `\s\S`）
- 簡化部分 regex（如 `(:|：)` 更改為 `[:：]`）
- 增加測試 (<https://regexr.com/6j8pf>)