### PR TITLE
fix(views/loginAccount): improve clarity of QR Code

### DIFF
--- a/src/views/loginAccount.vue
+++ b/src/views/loginAccount.vue
@@ -69,7 +69,7 @@
 
         <div v-show="mode == 'qrCode'">
           <div v-show="qrCodeImage" class="qr-code-container">
-            <img :src="qrCodeImage" />
+            <img :src="qrCodeImage" width="192px" />
           </div>
           <div class="qr-code-info">
             {{ qrCodeInformation }}
@@ -236,7 +236,7 @@ export default {
           QRCode.toDataURL(
             `https://music.163.com/login?codekey=${this.qrCodeKey}`,
             {
-              width: 192,
+              width: 384,
               margin: 0,
               color: {
                 dark: '#335eea',


### PR DESCRIPTION
渲染 384px 的 QR Code，而顯示在 192px 的方框中。這樣 QR Code 大小不變，但清晰度為原本的兩倍。

<img width="391" alt="image" src="https://user-images.githubusercontent.com/28441561/165126272-2346d135-1d4f-44a9-a534-c2aa3d4a56f8.png">

Fixed #1562