### PR TITLE
fix(components/TrackList): 修复在播放私人 FM 音乐时无法通过右键菜单播放、添加歌单歌曲

### DIFF
--- a/src/components/TrackList.vue
+++ b/src/components/TrackList.vue
@@ -226,9 +226,11 @@ export default {
       }
     },
     play() {
+      if (this.player._isPersonalFM) this.player._isPersonalFM = false;
       this.player.addTrackToPlayNext(this.rightClickedTrack.id, true);
     },
     addToQueue() {
+      if (this.player._isPersonalFM) this.player._isPersonalFM = false;
       this.player.addTrackToPlayNext(this.rightClickedTrack.id);
     },
     like() {


### PR DESCRIPTION
Bug：当播放来自私人 FM 的音乐时，在歌单页右键歌单歌曲：进行「播放」操作时没有播放这一首歌单歌曲，而是私人 FM 的歌曲出现了切换下一首歌的反应；进行「添加到队列」操作时无反应。  
![](https://user-images.githubusercontent.com/33573572/166708270-dc829c58-aea3-4399-ac78-16423e162ff6.gif)  
修复效果：  
![](https://user-images.githubusercontent.com/33573572/166715189-5a515584-3a91-4b53-9359-30229412949a.gif)

