### PR TITLE
fix: 歌词滚动效果的视觉缺陷

### DIFF
--- a/src/views/lyrics.vue
+++ b/src/views/lyrics.vue
@@ -187,6 +187,7 @@
               :key="index"
               class="line"
               :class="{
+                leaveHighlight: index === highlightLyricIndex - 1,
                 highlight: highlightLyricIndex === index,
               }"
               @click="clickLyricLine(line.time)"
@@ -693,12 +694,10 @@ export default {
       padding: 12px 18px;
       transition: 0.5s;
       border-radius: 12px;
+      width: 81%;
 
       &:hover {
         background: var(--color-secondary-bg-for-transparent);
-      }
-      &:active {
-        transform: scale(0.95);
       }
 
       span {
@@ -722,18 +721,91 @@ export default {
       margin-top: 0.1em;
     }
 
+    @keyframes highlightAnimation {
+      0% {
+        width: 81%;
+      }
+      100% {
+        width: 90%;
+      }
+    }
+
+    @keyframes highlightLyricAnimation {
+      0% {
+        font-size: 0.9em;
+      }
+      100% {
+        font-size: 1em;
+      }
+    }
+
+    @keyframes highlightTranslationAnimation {
+      0% {
+        font-size: 0.825em;
+      }
+      100% {
+        font-size: calc(0.825em / 0.9);
+      }
+    }
+
     .highlight {
-      transform-origin: center left;
-      transform: scale(1.05);
+      animation: highlightAnimation 0.5s;
+      animation-fill-mode: forwards;
     }
 
     .highlight span {
       opacity: 0.98;
       display: inline-block;
+      animation: highlightLyricAnimation 0.5s;
+      animation-fill-mode: forwards;
     }
 
     .highlight span.translation {
       opacity: 0.65;
+      animation: highlightTranslationAnimation 0.5s;
+      animation-fill-mode: forwards;
+    }
+
+    @keyframes leaveHighlightAnimation {
+      0% {
+        width: 90%;
+      }
+      100% {
+        width: 81%;
+      }
+    }
+
+    @keyframes leaveHighlightLyricAnimation {
+      0% {
+        font-size: 1em;
+      }
+      100% {
+        font-size: 0.9em;
+      }
+    }
+
+    @keyframes leaveHighlightTranslationAnimation {
+      0% {
+        font-size: calc(0.825em / 0.9);
+      }
+      100% {
+        font-size: 0.825em;
+      }
+    }
+
+    .leaveHighlight {
+      animation: leaveHighlightAnimation 0.5s;
+      animation-fill-mode: forwards;
+    }
+
+    .leaveHighlight span {
+      animation: leaveHighlightLyricAnimation 0.5s;
+      animation-fill-mode: forwards;
+    }
+
+    .leaveHighlight span.translation {
+      animation: leaveHighlightTranslationAnimation 0.5s;
+      animation-fill-mode: forwards;
     }
   }
 


### PR DESCRIPTION
通过使用`animation`与`key frame`调整单行歌词的容器宽度与字体大小，来修复之前使用`transform`导致的一些视觉缺陷
这顺便修复了歌词页面右上角`收起歌词页`按钮与单行歌词重叠的问题，现在它们之间有了一个小的间距

这个修改有一个小问题，当歌词index为`highlightLyricIndex - 1`时，一定会播放一次歌词缩小的动画，在手动调整歌曲进度后会感知到这一现象，正常播放时就是视觉上感觉还算和谐的歌词缩小

fix #1603