### PR TITLE
fix: 专辑分碟排序错误

### DIFF
--- a/src/views/album.vue
+++ b/src/views/album.vue
@@ -71,12 +71,12 @@
         </div>
       </div>
     </div>
-    <div v-if="Object.keys(tracksByDisc).length !== 1">
-      <div v-for="(disc, cd) in tracksByDisc" :key="cd">
-        <h2 class="disc">Disc {{ cd }}</h2>
+    <div v-if="tracksByDisc.length > 1">
+      <div v-for="(item, index) in tracksByDisc" :key="index">
+        <h2 class="disc">Disc {{ item.disc }}</h2>
         <TrackList
           :id="album.id"
-          :tracks="disc"
+          :tracks="item.tracks"
           :type="'album'"
           :album-object="album"
         />
@@ -153,7 +153,7 @@ import locale from '@/locale';
 import { splitSoundtrackAlbumTitle, splitAlbumTitle } from '@/utils/common';
 import NProgress from 'nprogress';
 import { isAccountLoggedIn } from '@/utils/auth';
-import { groupBy } from 'lodash';
+import { groupBy, toPairs, sortBy } from 'lodash';
 
 import ExplicitSymbol from '@/components/ExplicitSymbol.vue';
 import ButtonTwoTone from '@/components/ButtonTwoTone.vue';
@@ -222,7 +222,22 @@ export default {
       }
     },
     tracksByDisc() {
-      return groupBy(this.tracks, 'cd');
+      if (this.tracks.length <= 1) return [];
+      const pairs = toPairs(groupBy(this.tracks, 'cd'));
+      if (pairs.length === 1) {
+        return [
+          {
+            disc: pairs[0][0],
+            tracks: pairs[0][1],
+          },
+        ];
+      }
+      return sortBy(pairs, p => p[0]).map(items => {
+        return {
+          disc: items[0],
+          tracks: items[1],
+        };
+      });
     },
   },
   created() {


### PR DESCRIPTION
fix #1618 

对于以下情况的测试表现符合预期:
- `cd`字段为特定前缀 + 序号(此专辑内为`Day+序号`): https://music.163.com/album?id=73470981
- `cd`字段为从1开始的递增序列: https://music.163.com/album?id=71723112
- `cd`字段为从`01`开始的递增序列: https://music.163.com/album?id=2420303