### PR TITLE
fix: 歌名翻译文本位置 & FMCard背景颜色

### DIFF
--- a/src/components/FMCard.vue
+++ b/src/components/FMCard.vue
@@ -67,6 +67,11 @@ export default {
       )}?param=512y512`;
     },
   },
+  watch: {
+    track() {
+      this.getColor();
+    },
+  },
   created() {
     this.getColor();
     window.ok = this.getColor;
@@ -76,11 +81,7 @@ export default {
       this.player.playPersonalFM();
     },
     next() {
-      this.player.playNextFMTrack().then(result => {
-        if (result) {
-          this.getColor();
-        }
-      });
+      this.player.playNextFMTrack();
     },
     goToAlbum() {
       if (this.track.album.id === 0) return;
@@ -88,7 +89,6 @@ export default {
     },
     moveToFMTrash() {
       this.player.moveToFMTrash();
-      this.getColor();
     },
     getColor() {
       if (!this.player.personalFMTrack?.album?.picUrl) return;

--- a/src/components/TrackList.vue
+++ b/src/components/TrackList.vue
@@ -272,10 +272,15 @@ export default {
       }
     },
     copyLink() {
-      navigator.clipboard.writeText(
+      this.$copyText(
         `https://music.163.com/song?id=${this.rightClickedTrack.id}`
-      );
-      this.showToast(locale.t('toast.copied'));
+      )
+        .then(() => {
+          this.showToast(locale.t('toast.copied'));
+        })
+        .catch(err => {
+          this.showToast(`${locale.t('toast.copyFailed')}${err}`);
+        });
     },
     removeTrackFromQueue() {
       this.$store.state.player.removeTrackFromQueue(

--- a/src/components/TrackListItem.vue
+++ b/src/components/TrackListItem.vue
@@ -33,6 +33,9 @@
       <div class="container">
         <div class="title">
           {{ track.name }}
+          <span v-if="isSubTitle" :title="subTitle" class="sub-title">
+            ({{ subTitle }})
+          </span>
           <span v-if="isAlbum" class="featured">
             <ArtistsInLine
               :artists="track.ar"
@@ -42,9 +45,6 @@
           <span v-if="isAlbum && track.mark === 1318912" class="explicit-symbol"
             ><ExplicitSymbol
           /></span>
-          <span v-if="isSubTitle" :title="subTitle" class="sub-title">
-            ({{ subTitle }})
-          </span>
         </div>
         <div v-if="!isAlbum" class="artist">
           <span
@@ -317,7 +317,8 @@ button {
         opacity: 0.72;
       }
       .sub-title {
-        color: #aeaeae;
+        color: #7a7a7a;
+        opacity: 0.7;
         margin-left: 4px;
       }
     }


### PR DESCRIPTION
使歌名翻译一直处于歌名之后，其他信息之前
之前的行为：在专辑内，翻译和歌名中间可能会有其他信息

歌名翻译现在是半透明的，用于区分正在播放的歌名和翻译

FMCard的背景颜色现在会一直随着私人FM的歌曲改变
之前的行为：只有在FMCard里切歌才会改变