### PR TITLE
feat: Add time to lyric page

### DIFF
--- a/src/locale/lang/en.js
+++ b/src/locale/lang/en.js
@@ -166,6 +166,7 @@ export default {
     subTitleDefault: 'Show Alias for Subtitle by default',
     enableReversedMode: 'Enable Reversed Mode (Experimental)',
     enableCustomTitlebar: 'Enable custom title bar (Need restart)',
+    showLyricsTime: 'Display current time',
     lyricsBackground: {
       text: 'Show Lyrics Background',
       off: 'Off',

--- a/src/locale/lang/zh-CN.js
+++ b/src/locale/lang/zh-CN.js
@@ -173,6 +173,7 @@ export default {
       on: '打开',
       dynamic: '动态（GPU 占用较高）',
     },
+    showLyricsTime: '显示当前时间',
     closeAppOption: {
       text: '关闭主面板时...',
       ask: '询问',

--- a/src/locale/lang/zh-TW.js
+++ b/src/locale/lang/zh-TW.js
@@ -164,6 +164,7 @@ export default {
     subTitleDefault: '副標題使用別名',
     enableReversedMode: '啟用倒序播放功能 (實驗性功能)',
     enableCustomTitlebar: '啟用自訂標題列（重新啟動後生效）',
+    showLyricsTime: '顯示當前時間',
     lyricsBackground: {
       text: '顯示歌詞背景',
       off: '關閉',

--- a/src/locale/lang/zh-TW.js
+++ b/src/locale/lang/zh-TW.js
@@ -164,7 +164,7 @@ export default {
     subTitleDefault: '副標題使用別名',
     enableReversedMode: '啟用倒序播放功能 (實驗性功能)',
     enableCustomTitlebar: '啟用自訂標題列（重新啟動後生效）',
-    showLyricsTime: '顯示當前時間',
+    showLyricsTime: '顯示目前時間',
     lyricsBackground: {
       text: '顯示歌詞背景',
       off: '關閉',

--- a/src/views/lyrics.vue
+++ b/src/views/lyrics.vue
@@ -32,7 +32,7 @@
 
       <div class="left-side">
         <div>
-          <div class="date">
+          <div v-if="settings.showLyricsTime" class="date">
             {{ date }}
           </div>
           <div class="cover">

--- a/src/views/lyrics.vue
+++ b/src/views/lyrics.vue
@@ -346,20 +346,21 @@ export default {
     ...mapActions(['likeATrack']),
     initDate() {
       var _this = this;
+      clearInterval(this.timer);
       this.timer = setInterval(function () {
         _this.date = _this.formatTime(new Date());
       }, 1000);
     },
     formatTime(value) {
-      let hour = value.getHours();
-      let minute = value.getMinutes();
-      let second = value.getSeconds();
+      let hour = value.getHours().toString();
+      let minute = value.getMinutes().toString();
+      let second = value.getSeconds().toString();
       return (
-        (hour >= 10 ? hour : '0' + hour) +
+        hour.padStart(2, '0') +
         ':' +
-        (minute >= 10 ? minute : '0' + minute) +
+        minute.padStart(2, '0') +
         ':' +
-        (second >= 10 ? second : '0' + second)
+        second.padStart(2, '0')
       );
     },
     playPrevTrack() {

--- a/src/views/lyrics.vue
+++ b/src/views/lyrics.vue
@@ -32,6 +32,9 @@
 
       <div class="left-side">
         <div>
+          <div class="date">
+            {{ date }}
+          </div>
           <div class="cover">
             <div class="cover-container">
               <img :src="imageUrl" loading="lazy" />
@@ -245,6 +248,7 @@ export default {
       highlightLyricIndex: -1,
       minimize: true,
       background: '',
+      date: this.formatTime(new Date()),
     };
   },
   computed: {
@@ -327,6 +331,12 @@ export default {
   created() {
     this.getLyric();
     this.getCoverColor();
+    this.initDate();
+  },
+  beforeDestroy: function () {
+    if (this.timer) {
+      clearInterval(this.timer);
+    }
   },
   destroyed() {
     clearInterval(this.lyricsInterval);
@@ -334,6 +344,24 @@ export default {
   methods: {
     ...mapMutations(['toggleLyrics']),
     ...mapActions(['likeATrack']),
+    initDate() {
+      var _this = this;
+      this.timer = setInterval(function () {
+        _this.date = _this.formatTime(new Date());
+      }, 1000);
+    },
+    formatTime(value) {
+      let hour = value.getHours();
+      let minute = value.getMinutes();
+      let second = value.getSeconds();
+      return (
+        (hour >= 10 ? hour : '0' + hour) +
+        ':' +
+        (minute >= 10 ? minute : '0' + minute) +
+        ':' +
+        (second >= 10 ? second : '0' + second)
+      );
+    },
     playPrevTrack() {
       this.player.playPrevTrack();
     },
@@ -535,6 +563,20 @@ export default {
   transition: all 0.5s;
 
   z-index: 1;
+
+  .date {
+    max-width: 54vh;
+    margin: 24px 0;
+    color: var(--color-text);
+    text-align: center;
+    font-size: 4rem;
+    font-weight: 600;
+    opacity: 0.88;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 1;
+    overflow: hidden;
+  }
 
   .controls {
     max-width: 54vh;

--- a/src/views/settings.vue
+++ b/src/views/settings.vue
@@ -204,6 +204,22 @@
       </div>
       <div class="item">
         <div class="left">
+          <div class="title"> {{ $t('settings.showLyricsTime') }} </div>
+        </div>
+        <div class="right">
+          <div class="toggle">
+            <input
+              id="show-lyrics-time"
+              v-model="showLyricsTime"
+              type="checkbox"
+              name="show-lyrics-time"
+            />
+            <label for="show-lyrics-time"></label>
+          </div>
+        </div>
+      </div>
+      <div class="item">
+        <div class="left">
           <div class="title"> {{ $t('settings.lyricFontSize.text') }} </div>
         </div>
         <div class="right">
@@ -932,6 +948,17 @@ export default {
       set(value) {
         this.$store.commit('updateSettings', {
           key: 'lyricsBackground',
+          value,
+        });
+      },
+    },
+    showLyricsTime: {
+      get() {
+        return this.settings.showLyricsTime;
+      },
+      set(value) {
+        this.$store.commit('updateSettings', {
+          key: 'showLyricsTime',
           value,
         });
       },


### PR DESCRIPTION
在全屏歌词页面添加了时间的显示，并且在设置页面中增加了是否显示的设置项。
歌词页面示例图片（见红框部分）：
<img width="1674" alt="image" src="https://user-images.githubusercontent.com/30408959/172032264-ca4a294e-0faa-4e36-a189-36dffc24d006.png">
设置页面示例图片（见红框部分）：
<img width="1096" alt="image" src="https://user-images.githubusercontent.com/30408959/172032302-22756cae-407b-458e-8c55-07eab211ef51.png">
