### PR TITLE
fix(dockerfile): 设置 NCMAPI 版本

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN echo $'server { \n\
 
 RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.14/main libuv \
   && apk add --no-cache --update-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.14/main nodejs npm \
-  && npm i -g NeteaseCloudMusicApi
+  && npm i -g NeteaseCloudMusicApi@4.5.X
 
 COPY --from=build /app/dist /usr/share/nginx/html
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,9 +37,11 @@ RUN echo $'server { \n\
   } \n\
   }' > /etc/nginx/conf.d/default.conf
 
-RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.14/main libuv \
+COPY --from=build /app/package.json /usr/local/lib/
+
+RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.14/main libuv jq \
   && apk add --no-cache --update-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.14/main nodejs npm \
-  && npm i -g NeteaseCloudMusicApi@4.5.X
+  && npm i -g NeteaseCloudMusicApi@"$(jq -r '.dependencies.NeteaseCloudMusicApi' /usr/local/lib/package.json)"
 
 COPY --from=build /app/dist /usr/share/nginx/html
 


### PR DESCRIPTION
现在 `master` 分支下的 [`Dockerfile`](../blob/master/Dockerfile) 未规定 [NeteaseCloudMusicApi](https://github.com/Binaryify/NeteaseCloudMusicApi/releases) 的版本，构建 Docker 后运行会报错：

<details>

```
YesPlayMusic    | internal/modules/cjs/loader.js:905
YesPlayMusic    |   throw err;
YesPlayMusic    |   ^
YesPlayMusic    |
YesPlayMusic    | Error: Cannot find module './generateConfig'
YesPlayMusic    | Require stack:
YesPlayMusic    | - /usr/local/lib/node_modules/NeteaseCloudMusicApi/app.js
YesPlayMusic    |     at Function.Module._resolveFilename (internal/modules/cjs/loader.js:902:15)
YesPlayMusic    |     at Function.Module._load (internal/modules/cjs/loader.js:746:27)
YesPlayMusic    |     at Module.require (internal/modules/cjs/loader.js:974:19)
YesPlayMusic    |     at require (internal/modules/cjs/helpers.js:101:18)
YesPlayMusic    |     at Object.<anonymous> (/usr/local/lib/node_modules/NeteaseCloudMusicApi/app.js:2:24)
YesPlayMusic    |     at Module._compile (internal/modules/cjs/loader.js:1085:14)
YesPlayMusic    |     at Object.Module._extensions..js (internal/modules/cjs/loader.js:1114:10)
YesPlayMusic    |     at Module.load (internal/modules/cjs/loader.js:950:32)
YesPlayMusic    |     at Function.Module._load (internal/modules/cjs/loader.js:790:12)
YesPlayMusic    |     at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:75:12) {
YesPlayMusic    |   code: 'MODULE_NOT_FOUND',
YesPlayMusic    |   requireStack: [ '/usr/local/lib/node_modules/NeteaseCloudMusicApi/app.js' ]
YesPlayMusic    | }
```

</details>

~~此 PR 根据 [`package.json`](../blob/master/package.json#L27) 设置了 [`Dockerfile`](../blob/master/Dockerfile#L42) 中 NCMAPI 的版本号~~（~~`4.5.X`~~）。

`Dockerfile` 中的 NCMAPI 版本会根据 `package.json` 变更。
