### PR TITLE
Update Navbar.vue

### DIFF
--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -194,7 +194,7 @@ nav {
 
 @media (max-width: 1336px) {
   nav {
-    padding: 0 5vw;
+    padding: 0 7vw;
   }
 }
 


### PR DESCRIPTION
修复 窗口宽度小于1366px时前进后退按钮与窗口最大化按钮重叠