### PR TITLE
fix(player): 修复歌曲时长过长时的进度显示问题

### DIFF
--- a/src/components/Player.vue
+++ b/src/components/Player.vue
@@ -187,6 +187,7 @@ import '@/assets/css/slider.css';
 import ButtonIcon from '@/components/ButtonIcon.vue';
 import VueSlider from 'vue-slider-component';
 import { goToListSource, hasListSource } from '@/utils/playList';
+import { formatTrackTime } from '@/utils/common';
 
 export default {
   name: 'Player',
@@ -239,10 +240,7 @@ export default {
         : this.$router.push({ name: 'next' });
     },
     formatTrackTime(value) {
-      if (!value) return '';
-      let min = ~~((value / 60) % 60);
-      let sec = (~~(value % 60)).toString().padStart(2, '0');
-      return `${min}:${sec}`;
+      return formatTrackTime(value);
     },
     hasList() {
       return hasListSource();

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -221,7 +221,7 @@ export function bytesToSize(bytes) {
 
 export function formatTrackTime(value) {
   if (!value) return '';
-  let min = ~~((value / 60) % 60);
+  let min = ~~(value / 60);
   let sec = (~~(value % 60)).toString().padStart(2, '0');
   return `${min}:${sec}`;
 }


### PR DESCRIPTION
如图，选择时长大于一小时的曲目

![1](https://user-images.githubusercontent.com/65452214/215837395-2c5fbf85-9e9f-4873-8872-3c5a5338407f.png)

在如下两个地方显示异常：
lyrics-page: 
![lyrics-page1](https://user-images.githubusercontent.com/65452214/215838956-a7958812-59f4-4374-9cfb-7bc5017dc38f.png)
player:
![player1](https://user-images.githubusercontent.com/65452214/215839176-79f972e3-e8dc-4d31-8c7a-c5ec51b5c52d.png)

修复后：
lyrics-page:
![lyrics-page2](https://user-images.githubusercontent.com/65452214/215838279-6a709225-a280-47ba-b697-c1363ffde74a.png)
player:
![player2](https://user-images.githubusercontent.com/65452214/215838293-425d67d2-3d3b-429f-bac7-ef9f78562534.png)
