### PR TITLE
chore: define node engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "netease_api:run": "npx NeteaseCloudMusicApi"
   },
   "main": "background.js",
+  "engines": {
+    "node": "14 || 16"
+  },
   "dependencies": {
     "@unblockneteasemusic/rust-napi": "^0.4.0",
     "NeteaseCloudMusicApi": "^4.8.7",


### PR DESCRIPTION
The `@achrinza/node-ipc` version we use in 1.x does not allow
a version of Node.js greater than 17. As YesPlayMusic has been in
maintenance mode, we define our supported Node.js engine version
rather than upgrade this dependency.

It may indicate the Vercel platform to not use 18 (or greater) in their
deployment.

The error message is:

    error @achrinza/node-ipc@9.2.2: The engine "node" is incompatible with this module. Expected version "8 || 10 || 12 || 14 || 16 || 17". Got "18.12.1"
