### PR TITLE
fix: album.company显示问题

### DIFF
--- a/src/views/album.vue
+++ b/src/views/album.vue
@@ -96,7 +96,7 @@
         {{ $t('album.released') }}
         {{ album.publishTime | formatDate('MMMM D, YYYY') }}
       </div>
-      <div v-if="album.company !== null" class="copyright">
+      <div v-if="album.company" class="copyright">
         © {{ album.company }}
       </div>
     </div>


### PR DESCRIPTION
album.company返回的不是null，是个空字符。
所以判断album.company!==null为真，显示了一个空的company
![image](https://user-images.githubusercontent.com/16361564/226380732-12f751be-9e1c-45b9-aaf3-04c435c829a9.png)
