### PR TITLE
fix(player): Skip track when audio source not supported

### DIFF
--- a/src/utils/Player.js
+++ b/src/utils/Player.js
@@ -338,6 +338,10 @@ export default class {
       // code 3: MEDIA_ERR_DECODE
       if (errCode === 3) {
         this._playNextTrack(this._isPersonalFM);
+      } else if (errCode === 4) {
+        // code 4: MEDIA_ERR_SRC_NOT_SUPPORTED
+        store.dispatch('showToast', `无法播放: 不支持的音频格式`);
+        this._playNextTrack(this._isPersonalFM);
       } else {
         const t = this.progress;
         this._replaceCurrentTrackAudio(this.currentTrack, false, false).then(


### PR DESCRIPTION
修复某些情况下云盘中的音频格式不支持播放的问题，这种问题很少见，是因为某些 flac 文件在 chromium 中播放时会导致 ffmpeg 解码器出错，进而无法播放。

![image](https://user-images.githubusercontent.com/25524750/231195631-5234fda7-d9f9-47dd-8212-28cde524954e.png)

至于为什么 chromium 无法播放就不知道了，可能跟 flac 的文件格式不标准有关系，也可能是 chromium 的内部问题。本地的媒体播放器例如 VLC 都是可以正常播放的。