### PR TITLE
fix(NavBar): Fixed the issue of overlapping with the control bar

### DIFF
--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -194,7 +194,7 @@ nav {
 
 @media (max-width: 1336px) {
   nav {
-    padding: 0 5vw;
+    padding: 0 max(5vw, 90px);
   }
 }
 


### PR DESCRIPTION

在小尺寸下，这个导航栏有可能会和控制栏重叠（未hover时略显拥挤，hover时会重叠），增加了一个`max`函数来确定`padding`的最小值

Before：
![Cleanshot-2023-06-05-at-22 42 48](https://github.com/qier222/YesPlayMusic/assets/36695271/55dc85c1-7c59-428d-b0a2-b478a380d9a0)
![Cleanshot-2023-06-05-at-22 44 11](https://github.com/qier222/YesPlayMusic/assets/36695271/056d6bd1-8bef-447b-8829-430c45895c79)

After：
![Cleanshot-2023-06-05-at-22 45 13](https://github.com/qier222/YesPlayMusic/assets/36695271/7f90d01f-4494-46bc-a47d-4702179bcfae)
![Cleanshot-2023-06-05-at-22 45 07](https://github.com/qier222/YesPlayMusic/assets/36695271/84a03ca1-e16d-4091-9ca7-5a90a72edb01)

