### PR TITLE
fix(player): 插队曲目切换后下一首曲目丢失

### DIFF
--- a/src/utils/Player.js
+++ b/src/utils/Player.js
@@ -14,6 +14,8 @@ import { decode as base642Buffer } from '@/utils/base64';
 
 const PLAY_PAUSE_FADE_DURATION = 200;
 
+const INDEX_IN_PLAY_NEXT = -1;
+
 /**
  * @readonly
  * @enum {string}
@@ -255,8 +257,8 @@ export default class {
     const next = this._reversed ? this.current - 1 : this.current + 1;
 
     if (this._playNextList.length > 0) {
-      let trackID = this._playNextList.shift();
-      return [trackID, this.current];
+      let trackID = this._playNextList[0];
+      return [trackID, INDEX_IN_PLAY_NEXT];
     }
 
     // 循环模式开启，则重新播放当前模式下的相对的下一首
@@ -704,7 +706,12 @@ export default class {
       this._setPlaying(false);
       return false;
     }
-    this.current = index;
+    let next = index;
+    if (index === INDEX_IN_PLAY_NEXT) {
+      this._playNextList.shift();
+      next = this.current;
+    }
+    this.current = next;
     this._replaceCurrentTrack(trackID);
     return true;
   }


### PR DESCRIPTION
切换到下一首插队歌曲后，排在它后面的下一首歌会跟着从队列中消失。这个bug与 issue #1908, #1644 应该属于同一个问题，这个问题用文字描述比较抽象，这里上一张动图：

![插队播放bug](https://github.com/qier222/YesPlayMusic/assets/83274041/e0244d32-a76b-41b9-8a0c-fcfdd2a35bfd)

**原因：预加载歌曲会意外导致队列的下一首歌被移除。** 
获取下一首id时，队列中第一个元素会被移除并返回，这在切换下一首时没有影响，但在仅仅是为了“获得”的情况下，将导致其被意外移除

**思路：**
修改了方法 `_getNextTrack()`：永远只会返回队列第一个元素，不做移除操作，原本切换下一首需要的移除操作交给  `playNextTrack()` 完成。
