### PR TITLE
Fix: 右键播放歌曲无法激活播放栏

### DIFF
--- a/src/utils/Player.js
+++ b/src/utils/Player.js
@@ -823,6 +823,9 @@ export default class {
     this._howler?.once('play', () => {
       this._howler?.fade(0, this.volume, PLAY_PAUSE_FADE_DURATION);
 
+      // 播放时确保开启player.
+      // 避免因"忘记设置"导致在播放时播放器不显示的Bug
+      this._enabled = true;
       this._setPlaying(true);
       if (this._currentTrack.name) {
         setTitle(this._currentTrack);
@@ -879,7 +882,6 @@ export default class {
     autoPlayTrackID = 'first'
   ) {
     this._isPersonalFM = false;
-    if (!this._enabled) this._enabled = true;
     this.list = trackIDs;
     this.current = 0;
     this._playlistSource = {
@@ -936,13 +938,11 @@ export default class {
   addTrackToPlayNext(trackID, playNow = false) {
     this._playNextList.push(trackID);
     if (playNow) {
-      if (!this._enabled) this._enabled = true;
       this.playNextTrack();
     }
   }
   playPersonalFM() {
     this._isPersonalFM = true;
-    if (!this._enabled) this._enabled = true;
     if (this.currentTrackID !== this._personalFMTrack.id) {
       this._replaceCurrentTrack(this._personalFMTrack.id, true);
     } else {

--- a/src/utils/Player.js
+++ b/src/utils/Player.js
@@ -936,6 +936,7 @@ export default class {
   addTrackToPlayNext(trackID, playNow = false) {
     this._playNextList.push(trackID);
     if (playNow) {
+      if (!this._enabled) this._enabled = true;
       this.playNextTrack();
     }
   }


### PR DESCRIPTION
在阅读并理解了实现各种播放行为的代码逻辑后，我发现在实现"通过右键方式播放"的代码中缺少了设置显示状态的代码，导致当播放器处于隐藏状态时，无法更改其为显示状态。

```
 if (!this._enabled) this._enabled = true;
```

我初步想法是补充这一逻辑代码即可，就像其他播放行为的实现逻辑一样，但我认为这个逻辑应该集中在 `play()` 函数中，当播放器开始播放歌曲时，确保其为显示状态。

Close #1965 