### PR TITLE
fix: play icon not appear in Safari

### DIFF
--- a/src/components/Cover.vue
+++ b/src/components/Cover.vue
@@ -135,7 +135,7 @@ img {
   cursor: default;
   transition: 0.2s;
   .svg-icon {
-    height: 44%;
+    width: 50%;
     margin: {
       left: 4px;
     }


### PR DESCRIPTION
As you can see, the icon for the play button does not appear in Safari.

before:
<img width="950" alt="image" src="https://github.com/qier222/YesPlayMusic/assets/25883665/408a946d-ea4a-47f0-8073-b84a363f99cf">

after:
<img width="944" alt="image" src="https://github.com/qier222/YesPlayMusic/assets/25883665/feceea48-9214-4b77-917a-9de363f0eae6">