### PR TITLE
[Feature] support UnblockNeteaseMusic with docker-compose deploy.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,20 @@
 FROM node:16.13.1-alpine as build
 ENV VUE_APP_NETEASE_API_URL=/api
 WORKDIR /app
-RUN apk add --no-cache python3 make g++ git
+RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.tuna.tsinghua.edu.cn/g' /etc/apk/repositories &&\
+	apk add --no-cache python3 make g++ git
 COPY package.json yarn.lock ./
 RUN yarn install
 COPY . .
-RUN yarn build
+RUN yarn config set electron_mirror https://npmmirror.com/mirrors/electron/ && \
+    yarn build
 
 FROM nginx:1.20.2-alpine as app
 
 COPY --from=build /app/package.json /usr/local/lib/
 
-RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.14/main libuv \
+RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.tuna.tsinghua.edu.cn/g' /etc/apk/repositories &&\
+	apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.14/main libuv \
   && apk add --no-cache --update-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.14/main nodejs npm \
   && npm i -g $(awk -F \" '{if($2=="NeteaseCloudMusicApi") print $2"@"$4}' /usr/local/lib/package.json) \
   && rm -f /usr/local/lib/package.json
@@ -19,4 +22,4 @@ RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.14/m
 COPY --from=build /app/docker/nginx.conf.example /etc/nginx/conf.d/default.conf
 COPY --from=build /app/dist /usr/share/nginx/html
 
-CMD nginx ; exec npx NeteaseCloudMusicApi
+CMD nginx ; exec env NODE_TLS_REJECT_UNAUTHORIZED=0 npx NeteaseCloudMusicApi

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,4 @@ RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.tuna.tsinghua.edu.cn/g' /etc/apk/re
 COPY --from=build /app/docker/nginx.conf.example /etc/nginx/conf.d/default.conf
 COPY --from=build /app/dist /usr/share/nginx/html
 
-CMD nginx ; exec env NODE_TLS_REJECT_UNAUTHORIZED=0 npx NeteaseCloudMusicApi
+CMD nginx ; exec npx NeteaseCloudMusicApi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,10 @@ services:
 
   UnblockNeteaseMusic:
     image: pan93412/unblock-netease-music-enhanced
-    command: -o bilibili kugou kuwo pyncmd -p 80:443 -f 59.111.19.99
+    command: -o kugou kuwo migu bilibili pyncmd -p 80:443 -f 45.127.129.53 -e -
+    # environment:
+    #   JSON_LOG: true
+    #   LOG_LEVEL: debug
     networks:
       my_network:
         aliases:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     volumes:
       - /etc/localtime:/etc/localtime:ro
       - /etc/timezone:/etc/timezone:ro
+      - ./docker/nginx.conf.example:/etc/nginx/conf.d/default.conf:ro
     ports:
       - 80:80
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,5 +8,30 @@ services:
       - /etc/localtime:/etc/localtime:ro
       - /etc/timezone:/etc/timezone:ro
     ports:
-      - 80:80
+      - 1202:80
     restart: always
+    depends_on:
+      - UnblockNeteaseMusic
+    environment:
+      - NODE_TLS_REJECT_UNAUTHORIZED=0
+    networks:
+      my_network:
+
+  UnblockNeteaseMusic:
+    image: pan93412/unblock-netease-music-enhanced
+    command: -o bilibili kugou kuwo pyncmd -p 80:443 -f 59.111.19.99
+    environment:
+      - NODE_TLS_REJECT_UNAUTHORIZED=0
+    networks:
+      my_network:
+        aliases:
+          - music.163.com
+          - interface.music.163.com
+          - interface3.music.163.com
+          - interface.music.163.com.163jiasu.com
+          - interface3.music.163.com.163jiasu.com
+    restart: always
+
+networks:
+  my_network:
+    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - /etc/localtime:/etc/localtime:ro
       - /etc/timezone:/etc/timezone:ro
     ports:
-      - 1202:80
+      - 80:80
     restart: always
     depends_on:
       - UnblockNeteaseMusic
@@ -20,8 +20,6 @@ services:
   UnblockNeteaseMusic:
     image: pan93412/unblock-netease-music-enhanced
     command: -o bilibili kugou kuwo pyncmd -p 80:443 -f 59.111.19.99
-    environment:
-      - NODE_TLS_REJECT_UNAUTHORIZED=0
     networks:
       my_network:
         aliases:

--- a/docker/nginx.conf.example
+++ b/docker/nginx.conf.example
@@ -23,6 +23,7 @@ server {
     proxy_set_header        X-Forwarded-For $remote_addr;
     proxy_set_header        X-Forwarded-Host $remote_addr;
     proxy_set_header        X-NginX-Proxy true;
+
     proxy_pass              http://localhost:3000/;
   }
 }

--- a/docker/nginx.conf.example
+++ b/docker/nginx.conf.example
@@ -27,3 +27,34 @@ server {
     proxy_pass              http://localhost:3000/;
   }
 }
+
+server {
+        listen 0.0.0.0:80;
+        server_name music.163.com interface.music.163.com interface3.music.163.com;
+
+        location / {
+                proxy_pass http://UnblockNeteaseMusic:80;
+                proxy_set_header HOST 'music.163.com';
+        }
+}
+
+server {
+        listen 0.0.0.0:443 ssl;
+        server_name music.163.com interface.music.163.com interface3.music.163.com;
+
+        # ssl on;
+        # ssl_certificate /etc/nginx/ssl/163/server.crt;
+        # ssl_certificate_key /etc/nginx/ssl/163/server.key;
+
+        # ssl_session_timeout 10m;
+        # ssl_session_cache shared:SSL:10m;
+
+        # ssl_protocols  TLSv1 TLSv1.1 TLSv1.2;
+        # ssl_ciphers 'AES128+EECDH:AES128+EDH';
+        # ssl_prefer_server_ciphers on;
+
+        location / {
+                proxy_pass https://UnblockNeteaseMusic:443;
+                proxy_set_header HOST 'music.163.com';
+        }
+}

--- a/docker/nginx.conf.example
+++ b/docker/nginx.conf.example
@@ -27,34 +27,3 @@ server {
     proxy_pass              http://localhost:3000/;
   }
 }
-
-server {
-        listen 0.0.0.0:80;
-        server_name music.163.com interface.music.163.com interface3.music.163.com;
-
-        location / {
-                proxy_pass http://UnblockNeteaseMusic:80;
-                proxy_set_header HOST 'music.163.com';
-        }
-}
-
-server {
-        listen 0.0.0.0:443 ssl;
-        server_name music.163.com interface.music.163.com interface3.music.163.com;
-
-        # ssl on;
-        # ssl_certificate /etc/nginx/ssl/163/server.crt;
-        # ssl_certificate_key /etc/nginx/ssl/163/server.key;
-
-        # ssl_session_timeout 10m;
-        # ssl_session_cache shared:SSL:10m;
-
-        # ssl_protocols  TLSv1 TLSv1.1 TLSv1.2;
-        # ssl_ciphers 'AES128+EECDH:AES128+EDH';
-        # ssl_prefer_server_ciphers on;
-
-        location / {
-                proxy_pass https://UnblockNeteaseMusic:443;
-                proxy_set_header HOST 'music.163.com';
-        }
-}

--- a/docker/nginx.conf.example
+++ b/docker/nginx.conf.example
@@ -23,7 +23,6 @@ server {
     proxy_set_header        X-Forwarded-For $remote_addr;
     proxy_set_header        X-Forwarded-Host $remote_addr;
     proxy_set_header        X-NginX-Proxy true;
-
     proxy_pass              http://localhost:3000/;
   }
 }


### PR DESCRIPTION
- 扩展了一下 docker-compose.yml， 使得现在 docker 部署的实例，能够默认支持[网易云音乐解锁](https://github.com/UnblockNeteaseMusic/server)。
- 调整了一下 Dockerfile 里面的内容，使得能够在国内网络能够正常地 build YesPlayMusic 的镜像。