### PR TITLE
fix: 阻止搜索引擎爬虫爬取网站的内容

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,2 @@
 User-agent: *
-Disallow:
+Disallow: /


### PR DESCRIPTION
## Disallow栏不写东西的话Google之类的爬虫会默认自动爬取所有网站内容，导致搜索控制台里面多了一堆音乐专辑网页进去。
![image](https://github.com/qier222/YesPlayMusic/assets/55303494/feb0dc11-eece-4eee-8729-acb81e6df550)

禁用后：

![image](https://github.com/qier222/YesPlayMusic/assets/55303494/471b2fc7-c5c0-4922-961e-5322816a2eee)
