### PR TITLE
Use cover image for discord rpc

### DIFF
--- a/src/electron/ipcMain.js
+++ b/src/electron/ipcMain.js
@@ -240,7 +240,7 @@ export function initIpcMain(win, store, trayEventEmitter) {
       details: track.name + ' - ' + track.ar.map(ar => ar.name).join(','),
       state: track.al.name,
       endTimestamp: Date.now() + track.dt,
-      largeImageKey: 'logo',
+      largeImageKey: track.al.picUrl,
       largeImageText: 'Listening ' + track.name,
       smallImageKey: 'play',
       smallImageText: 'Playing',
@@ -252,7 +252,7 @@ export function initIpcMain(win, store, trayEventEmitter) {
     client.updatePresence({
       details: track.name + ' - ' + track.ar.map(ar => ar.name).join(','),
       state: track.al.name,
-      largeImageKey: 'logo',
+      largeImageKey: track.al.picUrl,
       largeImageText: 'YesPlayMusic',
       smallImageKey: 'pause',
       smallImageText: 'Pause',


### PR DESCRIPTION
I think this looks better than the app logo.
Closes #2069.

![image](https://github.com/user-attachments/assets/bdc1afbc-caea-4d5e-9b6a-c4f52bd9cd0d)