### PR TITLE
fix: fix build error due to ill-formatted *.vue

### DIFF
--- a/src/components/TrackListItem.vue
+++ b/src/components/TrackListItem.vue
@@ -42,7 +42,9 @@
               :exclude="$parent.albumObject.artist.name"
               prefix="-"
           /></span>
-          <span v-if="isAlbum && (track.mark & 1048576) === 1048576" class="explicit-symbol"
+          <span
+            v-if="isAlbum && (track.mark & 1048576) === 1048576"
+            class="explicit-symbol"
             ><ExplicitSymbol
           /></span>
         </div>

--- a/src/views/album.vue
+++ b/src/views/album.vue
@@ -28,7 +28,9 @@
           <span v-else>Compilation by Various Artists</span>
         </div>
         <div class="date-and-count">
-          <span v-if="(album.mark & 1048576) === 1048576" class="explicit-symbol"
+          <span
+            v-if="(album.mark & 1048576) === 1048576"
+            class="explicit-symbol"
             ><ExplicitSymbol
           /></span>
           <span :title="album.publishTime | formatDate">{{


### PR DESCRIPTION
使用 .prettierrc 配置重新格式化 *.vue，修复了 vercel 构建过程中 prettier 报错而无法完成构建的问题。

原问题日志可见 #2291.

Resolved #2291.