### PR TITLE
feat: media button support

### DIFF
--- a/src/components/Player.vue
+++ b/src/components/Player.vue
@@ -217,6 +217,13 @@ export default {
         : '';
     },
   },
+  mounted() {
+    this.setupMediaControls();
+    window.addEventListener("keydown", this.handleKeydown);
+  },
+  beforeDestroy() {
+    window.removeEventListener("keydown", this.handleKeydown);
+  },
   methods: {
     ...mapMutations(['toggleLyrics']),
     ...mapActions(['showToast', 'likeATrack']),
@@ -269,6 +276,39 @@ export default {
     },
     mute() {
       this.player.mute();
+    },
+
+    setupMediaControls() {
+      if ("mediaSession" in navigator) {
+        navigator.mediaSession.setActionHandler("play", () => {
+          this.playOrPause();
+        });
+        navigator.mediaSession.setActionHandler("pause", () => {
+          this.playOrPause();
+        });
+        navigator.mediaSession.setActionHandler("previoustrack", () => {
+          this.playPrevTrack();
+        });
+        navigator.mediaSession.setActionHandler("nexttrack", () => {
+          this.playNextTrack();
+        });
+      }
+    },
+
+    handleKeydown(event) {
+      switch (event.code) {
+        case "MediaPlayPause":
+          this.playOrPause();
+          break;
+        case "MediaTrackPrevious":
+          this.playPrevTrack();
+          break;
+        case "MediaTrackNext":
+          this.playNextTrack();
+          break;
+        default:
+          break;
+      }
     },
   },
 };


### PR DESCRIPTION
use "media key" on keyboard to manage player, toogle pause, prev song and next song

通过键盘上的媒体按键控制播放器. 切换暂停，切上一首下一首歌曲