### PR TITLE
Update build.yaml

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -97,19 +97,19 @@ jobs:
 
           use_vue_cli: true
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: YesPlayMusic-mac
           path: dist_electron/*-universal.dmg
           if-no-files-found: ignore
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: YesPlayMusic-win
           path: dist_electron/*Setup*.exe
           if-no-files-found: ignore
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: YesPlayMusic-linux
           path: dist_electron/*.AppImage


### PR DESCRIPTION
github弃用了actions/upload-artifact@v3，如果使用了会导致构建失败
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/