### PR TITLE
fix: 随机模式下当前播放歌曲于列表中的位置出现错误和不同步的情况

### DIFF
--- a/src/utils/Player.js
+++ b/src/utils/Player.js
@@ -130,6 +130,8 @@ export default class {
     if (shuffle) {
       this._shuffleTheList();
     }
+    // 同步当前歌曲在列表中的下标
+    this.current = this.list.indexOf(this.currentTrackID);
   }
   get reversed() {
     return this._reversed;

--- a/src/utils/Player.js
+++ b/src/utils/Player.js
@@ -892,7 +892,7 @@ export default class {
     if (autoPlayTrackID === 'first') {
       this._replaceCurrentTrack(this.list[0]);
     } else {
-      this.current = trackIDs.indexOf(autoPlayTrackID);
+      this.current = this.list.indexOf(autoPlayTrackID);
       this._replaceCurrentTrack(autoPlayTrackID);
     }
   }


### PR DESCRIPTION
随机模式下当前播放歌曲于列表中的位置出现错误和不同步，导致实际播放顺序与UI展示的列表不一致。

1. 随机模式下，双击歌单中下标为 N 的歌曲，当前歌曲的下标不会更新为 0，即随机列表中的第一首。
2. 随机模式下，假设当前播放歌曲在**原列表**中的下标为 M，退出随机模式后，当前播放歌曲的下标仍然是进入随机模式时播放歌曲在原列表中的下标为 N，不是实际的在原列表中的下标。

