### PR TITLE
feat: add tray icon color customization

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -388,7 +388,11 @@ class Background {
       // create tray
       if (isCreateTray) {
         this.trayEventEmitter = new EventEmitter();
-        this.ypmTrayImpl = createTray(this.window, this.trayEventEmitter);
+        this.ypmTrayImpl = createTray(
+          this.window,
+          this.trayEventEmitter,
+          this.store
+        );
       }
 
       // init ipcMain

--- a/src/electron/ipcMain.js
+++ b/src/electron/ipcMain.js
@@ -319,5 +319,8 @@ export function initIpcMain(win, store, trayEventEmitter) {
     ipcMain.on('updateTrayLikeState', (_, isLiked) => {
       trayEventEmitter.emit('updateLikeState', isLiked);
     });
+    ipcMain.on('updateTrayIcon', () => {
+      trayEventEmitter.emit('updateIcon');
+    });
   }
 }

--- a/src/locale/lang/en.js
+++ b/src/locale/lang/en.js
@@ -169,6 +169,12 @@ export default {
       light: 'Light',
       dark: 'Dark',
     },
+    trayIcon: {
+      text: 'Tray Icon Color',
+      auto: 'Auto',
+      light: 'Light',
+      dark: 'Dark',
+    },
     automaticallyCacheSongs: 'Automatically cache songs',
     clearSongsCache: 'Clear Songs Cache',
     cacheCount: 'Cached {song} songs ({size})',

--- a/src/locale/lang/tr.js
+++ b/src/locale/lang/tr.js
@@ -164,6 +164,12 @@ export default {
       light: 'Aydınlık',
       dark: 'Karanlık',
     },
+    trayIcon: {
+      text: 'Tepsi Simgesi Rengi',
+      auto: 'Otomatik',
+      light: 'Aydınlık',
+      dark: 'Karanlık',
+    },
     automaticallyCacheSongs: 'Müzikleri otomatik çerezle',
     clearSongsCache: 'Müzik çerezlerini temizle',
     cacheCount: 'Çerezlenen {song} Müzikler ({size})',

--- a/src/locale/lang/zh-CN.js
+++ b/src/locale/lang/zh-CN.js
@@ -170,6 +170,12 @@ export default {
       light: '浅色',
       dark: '深色',
     },
+    trayIcon: {
+      text: '托盘图标颜色',
+      auto: '自动',
+      light: '浅色',
+      dark: '深色',
+    },
     automaticallyCacheSongs: '自动缓存歌曲',
     clearSongsCache: '清除歌曲缓存',
     cacheCount: '已缓存 {song} 首 ({size})',

--- a/src/locale/lang/zh-TW.js
+++ b/src/locale/lang/zh-TW.js
@@ -166,6 +166,12 @@ export default {
       light: '淺色',
       dark: '深色',
     },
+    trayIcon: {
+      text: '工作列圖示顏色',
+      auto: '自動',
+      light: '淺色',
+      dark: '深色',
+    },
     automaticallyCacheSongs: '自動快取歌曲',
     clearSongsCache: '清除歌曲快取',
     cacheCount: '已快取 {song} 首 ({size})',

--- a/src/store/initLocalStorage.js
+++ b/src/store/initLocalStorage.js
@@ -30,6 +30,7 @@ let localStorage = {
     showLibraryDefault: false,
     subTitleDefault: false,
     linuxEnableCustomTitlebar: false,
+    trayIconTheme: 'auto',
     enabledPlaylistCategories,
     proxyConfig: {
       protocol: 'noProxy',

--- a/src/views/settings.vue
+++ b/src/views/settings.vue
@@ -56,6 +56,18 @@
           </select>
         </div>
       </div>
+      <div v-if="isElectron" class="item">
+        <div class="left">
+          <div class="title"> {{ $t('settings.trayIcon.text') }} </div>
+        </div>
+        <div class="right">
+          <select v-model="trayIconTheme">
+            <option value="auto">{{ $t('settings.trayIcon.auto') }}</option>
+            <option value="light">{{ $t('settings.trayIcon.light') }}</option>
+            <option value="dark">{{ $t('settings.trayIcon.dark') }}</option>
+          </select>
+        </div>
+      </div>
       <div class="item">
         <div class="left">
           <div class="title">
@@ -905,6 +917,21 @@ export default {
           value,
         });
         changeAppearance(value);
+      },
+    },
+    trayIconTheme: {
+      get() {
+        if (this.settings.trayIconTheme === undefined) return 'auto';
+        return this.settings.trayIconTheme;
+      },
+      set(value) {
+        this.$store.commit('updateSettings', {
+          key: 'trayIconTheme',
+          value,
+        });
+        if (this.isElectron) {
+          ipcRenderer.send('updateTrayIcon', value);
+        }
       },
     },
     musicQuality: {


### PR DESCRIPTION
## 新增托盘图标颜色设置选项

### 功能描述
在 Electron 环境下，新增了托盘图标颜色设置选项，允许用户自定义托盘图标的颜色主题，包括自动、浅色、深色三个选项。

### 为什么要增加这个功能
部分 Linux 桌面环境（如 Gnome）的 Topbar 的背景颜色在深色模式和浅色模式下都是深色的，Tray Icon 无法清晰地显示在 Topbar 里（如下图）。

<img width="165" height="94" alt="image" src="https://github.com/user-attachments/assets/722d0a19-61cf-4ed7-92da-a225dfb25f8a" />


### 修改内容

#### 1. 设置默认值
- **文件**: `src/store/initLocalStorage.js`
- **修改**: 添加 `trayIconTheme: 'auto'` 默认配置

#### 2. 国际化支持
为所有语言文件添加托盘图标颜色相关翻译：
- **`src/locale/lang/zh-CN.js`**: 托盘图标颜色 / 自动 / 浅色 / 深色
- **`src/locale/lang/en.js`**: Tray Icon Color / Auto / Light / Dark
- **`src/locale/lang/tr.js`**: Tepsi Simgesi Rengi / Otomatik / Aydınlık / Karanlık
- **`src/locale/lang/zh-TW.js`**: 工作列圖示顏色 / 自動 / 淺色 / 深色

#### 3. UI 界面
- **文件**: `src/views/settings.vue`
- **修改**: 
  - 在外观设置后添加托盘图标颜色选择下拉框（仅 Electron 环境显示）
  - 添加 `trayIconTheme` 计算属性，实现双向绑定和 IPC 通信

#### 4. 托盘图标逻辑
- **文件**: `src/electron/tray.js`
- **修改**:
  - 修改 `createTray` 函数接受 `store` 参数
  - 在两个托盘实现类（`YPMTrayLinuxImpl` 和 `YPMTrayWindowsImpl`）中：
    - 构造函数接受 `store` 参数
    - 添加 `updateIcon()` 方法用于动态更新图标
    - 添加 `updateIcon` 事件监听器
  - 实现根据设置值决定图标主题的逻辑：
    - `auto`: 跟随系统主题（深色系统使用浅色图标，浅色系统使用深色图标）
    - `light`: 始终使用浅色图标（适用于深色背景）
    - `dark`: 始终使用深色图标（适用于浅色背景）

#### 5. 主进程通信
- **文件**: `src/background.js`
- **修改**: 调用 `createTray` 时传入 `store` 参数

#### 6. IPC 事件处理
- **文件**: `src/electron/ipcMain.js`
- **修改**: 添加 `updateTrayIcon` IPC 监听器，触发 `updateIcon` 

### 功能特性
- ✅ 支持三种模式：自动、浅色、深色
- ✅ 设置变更后即时生效，无需重启应用
- ✅ 支持所有平台（Windows、macOS、Linux）
- ✅ 完整的国际化支持（简体中文、繁体中文、英文、土耳其语）
- ✅ 仅在 Electron 环境下显示此设置项
- ✅ 遵循项目现有代码规范和架构

### 技术实现
1. 用户在设置页面选择托盘图标颜色
2. 设置通过 Vuex 保存到 localStorage
3. 触发 IPC 消息到主进程
4. 主进程通过 EventEmitter 通知托盘实现类
5. 托盘实现类读取设置并动态更新图标

### 相关 Issues
#2413 #2196 #1533