### PR TITLE
fix: lyrics.js 中的时间戳解析

### DIFF
--- a/src/utils/lyrics.js
+++ b/src/utils/lyrics.js
@@ -64,8 +64,9 @@ function parseLyric(lrc) {
 
     for (const timestamp of lyricTimestamps.matchAll(extractTimestampRegex)) {
       const { min, sec, ms } = timestamp.groups;
-      const rawTime = timestamp[0];
-      const time = Number(min) * 60 + Number(sec) + Number(ms ?? 0) * 0.001;
+      const validMs = ms?.slice(0, 2) ?? '00';
+      const rawTime = `[${min}:${sec}.${validMs}]`;
+      const time = Number(min) * 60 + Number(sec) + Number(validMs) * 0.01;
 
       /** @type {ParsedLyric} */
       const parsedLyric = { rawTime, time, content: trimContent(content) };


### PR DESCRIPTION
## 摘要

- 更新了时间戳解析逻辑，确保毫秒的格式化和计算正确无误。
- 调整了 rawTime 格式，统一使用两位数表示毫秒（其实应当是百分之一秒）以保证一致性。

## bug 复现

以  `K歌之王 AIR (Day Version)`  https://music.163.com/song?id=2756303345 为例，打开歌词页，发音模式下发音歌词不会显示。

<img width="987" height="835" alt="image" src="https://github.com/user-attachments/assets/99379d99-7bf7-4ac5-b8ff-4790310dfb68" />

## bug 原因

其歌词 API 返回的`原文`和`发音`两个字段分别如下：

```bash
# 原文 lrc
[00:12.92]我唱得不够动人你别皱眉\n[00:19.57]我愿意和你约定至死\n...

# 发音 romalrc
[00:12.920]o coeng da ba gao dong yen nei bi zao mei\n[00:19.570]o yvn yi wo nei yoe ding zi sei...
```

可以发现时间戳部分格式不统一，**导致 rawTime 和 time 的解析不一致**，进而两部分歌词无法匹配。

```ts
// 原文解析为
{
  time: 12.092,
  rawTime: '[00:12.92]'
}

// 发音解析为
{
  time: 12.92,
  rawTime: '[00:12.920]'
}
```

`src/utils/lyrics.js` 中将小数点后的部分理解成毫秒，这是错误的。按照 [lrc 格式](https://zh.wikipedia.org/wiki/LRC%E6%A0%BC%E5%BC%8F) 约定，小数点后的数字指**百分之一秒**，并有且只有**两位**。

## 修复方案

- `src/utils/lyrics.js` 文件 `parseLyric(lrc)` 方法中，将小数点后的部分修改为**百分之一秒**。
- 针对网易云有时会返回不规范的 lrc 文本（例如小数点后变成 3 位）。应当统一作截断处理，即 `ms.slice(0, 2)`

## 修复结果：

发音正常显示。

<img width="991" height="832" alt="image" src="https://github.com/user-attachments/assets/f0be7e94-0b1a-4d18-9f98-e348ff2bfec7" />

