### PR TITLE
fix(Player): 修复拖动控件时误触父元素点击事件的问题

### DIFF
--- a/src/components/Player.vue
+++ b/src/components/Player.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="player" @click="toggleLyrics">
+  <div class="player" @click="handleClick" @mousedown="handleMouseDown">
     <div
       class="progress-bar"
       :class="{
@@ -195,6 +195,11 @@ export default {
     ButtonIcon,
     VueSlider,
   },
+  data() {
+    return {
+      mouseDownTarget: null,
+    };
+  },
   computed: {
     ...mapState(['player', 'settings', 'data']),
     currentTrack() {
@@ -227,6 +232,14 @@ export default {
   methods: {
     ...mapMutations(['toggleLyrics']),
     ...mapActions(['showToast', 'likeATrack']),
+    handleClick(event) {
+      if (event.target == this.mouseDownTarget) {
+        this.toggleLyrics();
+      }
+    },
+    handleMouseDown(event) {
+      this.mouseDownTarget = event.target;
+    },
     playPrevTrack() {
       this.player.playPrevTrack();
     },


### PR DESCRIPTION
修复issue#2442
进度条等子标签在拖动后落在该控件外、父元素内时，会触发父元素的点击事件，即打开歌词面板。这一操作有可能被用户误触。
解决方法是让触发click事件的元素和触发mousedown事件的元素（最开始点击的元素）进行比较，如果一样就正常触发弹出歌词面板，如果不一样，说明用户的光标进行了元素的偏移，判定为误触。

Fixed #2442