### PR TITLE
fix: MPRIS D-Bus 断连后 seeked 事件导致崩溃 (#2204)

### DIFF
--- a/src/electron/mpris.js
+++ b/src/electron/mpris.js
@@ -44,11 +44,11 @@ export function createMpris(window) {
 
   ipcMain.on('playerCurrentTrackTime', (e, position) => {
     player.getPosition = () => position * 1000 * 1000;
-    player.seeked(position * 1000 * 1000);
+    try { player.seeked(position * 1000 * 1000); } catch {}
   });
 
   ipcMain.on('seeked', (e, position) => {
-    player.seeked(position * 1000 * 1000);
+    try { player.seeked(position * 1000 * 1000); } catch {}
   });
 
   ipcMain.on('switchRepeatMode', (e, mode) => {


### PR DESCRIPTION
## Summary

- 修复 Linux 下 D-Bus/MPRIS 连接断开后，`player.seeked()` 抛出 "Tried to write a message to a closed stream" 未捕获异常导致 Electron 主进程崩溃的问题
- 在两处 `player.seeked()` 调用添加 try-catch，D-Bus 不可用时静默忽略

Closes #2204

## Test plan

- [ ] Linux 下正常启动应用并播放音乐，确认 MPRIS 媒体控制正常
- [ ] 模拟 D-Bus 断连（如 kill dbus-daemon）后拖动进度条，确认不再弹出错误对话框

🤖 Generated with [Claude Code](https://claude.com/claude-code)